### PR TITLE
Added Keyboard Shortcuts For Opacity

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Pennywise – MacOS application that allows you to open URLs in a floating window that always stays on top.",
   "productName": "Pennywise",
   "author": "Kamran Ahmed <kamranahmed.se@gmail.com>",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "main": "public/electron.js",
   "homepage": "./",

--- a/public/electron.js
+++ b/public/electron.js
@@ -28,8 +28,6 @@ function createWindow() {
     mainWindow.show();
     bindIpc();
   });
-  
-  
 
   mainWindow.on('closed', function () {
     mainWindow = null;

--- a/public/electron.js
+++ b/public/electron.js
@@ -28,6 +28,8 @@ function createWindow() {
     mainWindow.show();
     bindIpc();
   });
+  
+  
 
   mainWindow.on('closed', function () {
     mainWindow = null;
@@ -42,7 +44,7 @@ function createWindow() {
     mainWindow.webContents.openDevTools();
   }
 
-  setMainMenu();
+  setMainMenu(mainWindow);
 }
 
 // Binds the methods for renderer/electron communication

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,4 +1,4 @@
-const { app, Menu, shell } = require('electron');
+const { app, Menu, shell, ipcRenderer } = require('electron');
 
 module.exports = {
   setMainMenu
@@ -6,7 +6,25 @@ module.exports = {
 
 const isWindows = process.platform === 'win32';
 
-function setMainMenu() {
+function minus(mainWindow) {
+  const opacity = (mainWindow.getOpacity() * 100) - 10;
+  if (opacity < 20) {
+   return 20 / 100;
+  } else  {
+    return opacity / 100;
+  }
+}
+
+function plus(mainWindow) {
+  const opacity = (mainWindow.getOpacity() * 100) + 10;
+  if (opacity > 100) {
+    return 100 / 100;
+  } else  {
+    return opacity / 100;
+  }
+}
+
+function setMainMenu(mainWindow) {
   const template = [
     {
       label: isWindows ? 'File' : app.getName(),
@@ -23,6 +41,20 @@ function setMainMenu() {
     {
       label: 'Edit',
       submenu: [
+        {
+          label: 'Lower Opacity',
+          accelerator: 'CmdOrCtrl+-',
+          click() {
+            mainWindow.setOpacity(minus(mainWindow));
+          }
+        },
+        {
+          label: 'Increase Opacity',
+          accelerator: 'CmdOrCtrl+=',
+          click() {
+            mainWindow.setOpacity(plus(mainWindow));
+          }
+        },
         { role: 'undo' },
         { role: 'redo' },
         { type: 'separator' }, //just adds a line visually

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,10 +1,10 @@
-const { app, Menu, shell } = require("electron");
+const { app, Menu, shell } = require('electron');
 
 module.exports = {
   setMainMenu
 };
 
-const isWindows = process.platform === "win32";
+const isWindows = process.platform === 'win32';
 
 function getUpdatedOpacity(currentOpacity, updateFactor) {
   let newOpacity = currentOpacity + updateFactor;
@@ -21,11 +21,11 @@ function getUpdatedOpacity(currentOpacity, updateFactor) {
 function setMainMenu(mainWindow) {
   const template = [
     {
-      label: isWindows ? "File" : app.getName(),
+      label: isWindows ? 'File' : app.getName(),
       submenu: [
         {
-          label: isWindows ? "Exit" : `Quit ${app.getName()}`,
-          accelerator: isWindows ? null : "CmdOrCtrl+Q",
+          label: isWindows ? 'Exit' : `Quit ${app.getName()}`,
+          accelerator: isWindows ? null : 'CmdOrCtrl+Q',
           click() {
             app.quit();
           }
@@ -33,11 +33,11 @@ function setMainMenu(mainWindow) {
       ]
     },
     {
-      label: "Edit",
+      label: 'Edit',
       submenu: [
         {
-          label: "Lower Opacity",
-          accelerator: "CmdOrCtrl+Down",
+          label: 'Lower Opacity',
+          accelerator: 'CmdOrCtrl+Down',
           click() {
             mainWindow.setOpacity(
               getUpdatedOpacity(mainWindow.getOpacity(), -0.1)
@@ -45,29 +45,29 @@ function setMainMenu(mainWindow) {
           }
         },
         {
-          label: "Increase Opacity",
-          accelerator: "CmdOrCtrl+Up",
+          label: 'Increase Opacity',
+          accelerator: 'CmdOrCtrl+Up',
           click() {
             mainWindow.setOpacity(
               getUpdatedOpacity(mainWindow.getOpacity(), 0.1)
             );
           }
         },
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" }, //just adds a line visually
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectall" }
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' }, //just adds a line visually
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectall' }
       ]
     },
     {
-      label: "Tools",
+      label: 'Tools',
       submenu: [
         {
           label: 'Development Window',
-          accelerator: "CmdOrCtrl+Alt+I",
+          accelerator: 'CmdOrCtrl+Alt+I',
           click() {
             mainWindow.webContents.openDevTools();
           }
@@ -75,12 +75,12 @@ function setMainMenu(mainWindow) {
       ]
     },
     {
-      label: "Help",
+      label: 'Help',
       submenu: [
         {
-          label: "Learn More",
+          label: 'Learn More',
           click() {
-            shell.openExternal("https://electronjs.org");
+            shell.openExternal('https://electronjs.org');
           }
         }
       ]

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,37 +1,31 @@
-const { app, Menu, shell, ipcRenderer } = require('electron');
+const { app, Menu, shell } = require("electron");
 
 module.exports = {
   setMainMenu
 };
 
-const isWindows = process.platform === 'win32';
+const isWindows = process.platform === "win32";
 
-function minus(mainWindow) {
-  const opacity = (mainWindow.getOpacity() * 100) - 10;
-  if (opacity < 20) {
-   return 20 / 100;
-  } else  {
-    return opacity / 100;
-  }
-}
+function getUpdatedOpacity(currentOpacity, updateFactor) {
+  let newOpacity = currentOpacity + updateFactor;
 
-function plus(mainWindow) {
-  const opacity = (mainWindow.getOpacity() * 100) + 10;
-  if (opacity > 100) {
-    return 100 / 100;
-  } else  {
-    return opacity / 100;
+  if (newOpacity >= 1) {
+    return 1;
+  } else if (newOpacity <= 0.2) {
+    return 0.2;
+  } else {
+    return newOpacity;
   }
 }
 
 function setMainMenu(mainWindow) {
   const template = [
     {
-      label: isWindows ? 'File' : app.getName(),
+      label: isWindows ? "File" : app.getName(),
       submenu: [
         {
-          label: isWindows ? 'Exit' : `Quit ${app.getName()}`,
-          accelerator: isWindows ? null : 'CmdOrCtrl+Q',
+          label: isWindows ? "Exit" : `Quit ${app.getName()}`,
+          accelerator: isWindows ? null : "CmdOrCtrl+Q",
           click() {
             app.quit();
           }
@@ -39,38 +33,54 @@ function setMainMenu(mainWindow) {
       ]
     },
     {
-      label: 'Edit',
+      label: "Edit",
       submenu: [
         {
-          label: 'Lower Opacity',
-          accelerator: 'CmdOrCtrl+-',
+          label: "Lower Opacity",
+          accelerator: "CmdOrCtrl+Down",
           click() {
-            mainWindow.setOpacity(minus(mainWindow));
+            mainWindow.setOpacity(
+              getUpdatedOpacity(mainWindow.getOpacity(), -0.1)
+            );
           }
         },
         {
-          label: 'Increase Opacity',
-          accelerator: 'CmdOrCtrl+=',
+          label: "Increase Opacity",
+          accelerator: "CmdOrCtrl+Up",
           click() {
-            mainWindow.setOpacity(plus(mainWindow));
+            mainWindow.setOpacity(
+              getUpdatedOpacity(mainWindow.getOpacity(), 0.1)
+            );
           }
         },
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' }, //just adds a line visually
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        { role: 'selectall' }
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" }, //just adds a line visually
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectall" }
       ]
     },
     {
-      label: 'Help',
+      label: "Tools",
       submenu: [
         {
-          label: 'Learn More',
+          label: 'Development Window',
+          accelerator: "CmdOrCtrl+Alt+I",
           click() {
-            shell.openExternal('https://electronjs.org');
+            mainWindow.webContents.openDevTools();
+          }
+        }
+      ]
+    },
+    {
+      label: "Help",
+      submenu: [
+        {
+          label: "Learn More",
+          click() {
+            shell.openExternal("https://electronjs.org");
           }
         }
       ]

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -17,7 +17,7 @@ class Settings extends React.Component {
   onOpacityChange = (e) => {
     this.setState({
       opacity: e.target.value
-    });
+  });
 
     this.setOpacity(e.target.value);
   };

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -10,65 +10,6 @@ class Settings extends React.Component {
     opacity: ipcRenderer.sendSync('opacity.get')
   };
 
-  componentWillMount() {
-    window.addEventListener("keypress", this.handleKeyPress, false);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("keypress", this.handleKeyPress);
-  }
-
-  handleKeyPress = e => {
-    var ctrlDown = false,
-        ctrlKey = 17,
-        cmdKey = 91,
-        minus = 189,
-        plus = 187,
-        opacity = this.state.opacity,
-        evtobj = window.event? event : e;
-    
-    if (e.keyCode === ctrlKey || e.keyCode === cmdKey) ctrlDown = true;
-    
-    if (evtobj.keyCode === minus && ctrlDown) {
-      this.reduceOpacity(opacity - 10);
-    }
-    if (evtobj.keyCode === plus && ctrlDown) {
-      this.increaseOpacity(opacity + 10);
-    }
-  }
-
-  reduceOpacity = value => {
-    if (value < 20) {
-      this.setState({
-        opacity: 20
-      });
-      
-      this.setOpacity(20);
-    } else {
-      this.setState({
-        opacity: value
-      });
-      
-      this.setOpacity(value);
-    }
-  };
-
-  increaseOpacity = value => {
-    if (value > 100) {
-      this.setState({
-        opacity: 100
-      });
-      
-      this.setOpacity(100);
-    } else {
-      this.setState({
-        opacity: value
-      });
-      
-      this.setOpacity(value);
-    }
-  };
-
   setOpacity = debounce((opacity) => {
     ipcRenderer.send('opacity.set', opacity);
   }, 500);

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -10,6 +10,65 @@ class Settings extends React.Component {
     opacity: ipcRenderer.sendSync('opacity.get')
   };
 
+  componentWillMount() {
+    window.addEventListener("keypress", this.handleKeyPress, false);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("keypress", this.handleKeyPress);
+  }
+
+  handleKeyPress = e => {
+    var ctrlDown = false,
+        ctrlKey = 17,
+        cmdKey = 91,
+        minus = 189,
+        plus = 187,
+        opacity = this.state.opacity,
+        evtobj = window.event? event : e;
+    
+    if (e.keyCode === ctrlKey || e.keyCode === cmdKey) ctrlDown = true;
+    
+    if (evtobj.keyCode === minus && ctrlDown) {
+      this.reduceOpacity(opacity - 10);
+    }
+    if (evtobj.keyCode === plus && ctrlDown) {
+      this.increaseOpacity(opacity + 10);
+    }
+  }
+
+  reduceOpacity = value => {
+    if (value < 20) {
+      this.setState({
+        opacity: 20
+      });
+      
+      this.setOpacity(20);
+    } else {
+      this.setState({
+        opacity: value
+      });
+      
+      this.setOpacity(value);
+    }
+  };
+
+  increaseOpacity = value => {
+    if (value > 100) {
+      this.setState({
+        opacity: 100
+      });
+      
+      this.setOpacity(100);
+    } else {
+      this.setState({
+        opacity: value
+      });
+      
+      this.setOpacity(value);
+    }
+  };
+
   setOpacity = debounce((opacity) => {
     ipcRenderer.send('opacity.set', opacity);
   }, 500);


### PR DESCRIPTION
cmd || ctrl & +: increase opacity by 10 until 100%.
cmd || crtl & -: decrease opacity by 10 until 20%

Works on mac, unknown if works on mobile should work though if someone has a windows pc to test on