### PR TITLE
Fix minor grammar mistake in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Pennywise allows you to open anything in a **small floating window that always s
 * **Adjustable opacity** – it gets out of your way while you work
 * **Resize and place** it anywhere
 * **Shortcuts** to make you more productive
-* Let's you **multitask** while you work
+* Lets you **multitask** while you work
 * **Opensource** licensed under MIT
 * **Lean** small resource footprint, minimal User Interface.
 * **Cross-platform** works on MacOS, Windows and Linux


### PR DESCRIPTION
Hi! Just a quick heads-up, I spotted this small error while I was reading the readme. They're often mixed up, but `let's` is a contraction of "let us", while `lets` means "to allow" or "to enable". Pennywise _allows_ you to multitask while you work, so in this case you want `lets` 🙂

Also, thanks for making this app! I've been looking for something like this to use on my mac at work 😄