### PR TITLE
Fix for issue : Pennywise not reopening on Mac

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -72,7 +72,7 @@ function bindIpc() {
 // Makes the app start receiving the mouse interactions again
 function disableDetachedMode() {
   app.dock && app.dock.setBadge('');
-  mainWindow.setIgnoreMouseEvents(false);
+  //mainWindow.setIgnoreMouseEvents(false);
 }
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
**What does this PR do?**
Pennywise wouldn't reopen when closed on MacOS X. Building via Terminal pointed to an error to that line of code. Commenting that line fixes issue and doesn't break any functionality.

**What platforms did you test it on?**
MacOS X