### PR TITLE
Replace not not in isDev with nothing

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -17,7 +17,7 @@ function createWindow() {
     show: false,
   });
 
-  const isDev = !!process.env.APP_URL;
+  const isDev = process.env.APP_URL;
   if (process.env.APP_URL) {
     mainWindow.loadURL(process.env.APP_URL);
   } else {


### PR DESCRIPTION
**What does this PR do?**
Replaces ```const isDev = !!process.env.APP_URL;``` with ```const isDev = process.env.APP_URL;``` to make the code easier to read. Program still runs fine.

**What platforms did you test it on?**
MacOS X