### PR TITLE
Adding PDF support requires electron-pdf-window

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap": "^4.1.3",
+    "electron-pdf-window": "^1.0.12",
     "font-awesome": "^4.7.0",
     "is-url": "^1.2.4",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
**What does this PR do?**
Add a required library to package.json



