### PR TITLE
 Synchronize opacity of mainWindow and opacity of state in Settings

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -42,18 +42,20 @@ function getOpacityMenuItems(mainWindow) {
       label: 'Decrease Opacity',
       accelerator: 'CmdOrCtrl+Shift+Down',
       click() {
-        mainWindow.setOpacity(
-          getUpdatedOpacity(mainWindow.getOpacity(), -0.1)
-        );
+        const nextOpacity = getUpdatedOpacity(mainWindow.getOpacity(), -0.1);
+
+        mainWindow.webContents.send('opacity.sync', nextOpacity * 100);
+        mainWindow.setOpacity(nextOpacity);
       }
     },
     {
       label: 'Increase Opacity',
       accelerator: 'CmdOrCtrl+Shift+Up',
       click() {
-        mainWindow.setOpacity(
-          getUpdatedOpacity(mainWindow.getOpacity(), 0.1)
-        );
+        const nextOpacity = getUpdatedOpacity(mainWindow.getOpacity(), 0.1);
+
+        mainWindow.webContents.send('opacity.sync', nextOpacity * 100);
+        mainWindow.setOpacity(nextOpacity);
       }
     },
     { type: 'separator' },

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,6 @@ Because the application helps in floating and [Pennywise loved to do that](http:
 ## Planned Roadmap
 
 * [ ] Open local files – PDFs, Images, Video, MP3 etc
-* [ ] Shortcut to change opacity
 * [ ] Global shortcut to load currently selected URL
 * [ ] Persist options and linking options to website
 * [ ] Option to let the clicks pass through

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -10,11 +10,23 @@ class Settings extends React.Component {
     opacity: ipcRenderer.sendSync('opacity.get')
   };
 
+  componentDidMount() {
+    ipcRenderer.on('opacity.sync', this.onOpacitySync);
+  }
+
+  componentWillUnmount() {
+    ipcRenderer.removeListener('opacity.sync', this.onOpacitySync);
+  }
+
   // Debounce the setter so to avoid bombarding
   // electron with the opacity change requests
   setOpacity = debounce((opacity) => {
     ipcRenderer.send('opacity.set', opacity);
   }, 400);
+
+  onOpacitySync = (event, opacity) => {
+    this.setState({ opacity });
+  }
 
   onOpacityChange = (e) => {
     this.setState({


### PR DESCRIPTION
**What does this PR do?**
Bug fix about opacity synchronize between mainWindow and state in Settings.

**What platforms did you test it on?**
Mac OS Sierra 10.12.5

## Notice

I named that IPC channel about synchronize opacity is `opacity.sync`. I don't know what is the best name. If you don't like it, Please change that name.

I know that `Shortcut to change opacity` is completed. So I delete it in `README.md`.