### PR TITLE
Add hot-key about close-window.

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -69,6 +69,8 @@ function setMainMenu(mainWindow) {
     {
       label: isWindows ? 'File' : app.getName(),
       submenu: [
+        { role: 'close' },
+        { type: 'separator' },
         {
           label: isWindows ? 'Exit' : `Quit ${app.getName()}`,
           accelerator: isWindows ? null : 'CmdOrCtrl+Q',


### PR DESCRIPTION
**What does this PR do?**
Add hot-key in menu.

I though strangely when using `pennywise`. Because `cmd + w` key doesn't active about close window. I think that `close window` is necessary feature in application. I want to accept this.

When press `cmd + w` in MacOS (It may be another key In window), It works with the same logic as closing a window with a mouse. Therefore, I don't think it's a problem to be added.

Generally, `Quit {app}` menu is independent of the separator bar in menu. So I add `separator` too.

**What platforms did you test it on?**
Mac OS Sierra 10.12.5
