### PR TITLE
Update url displayed in navbar when links are clicked

### DIFF
--- a/src/components/nav-bar/index.js
+++ b/src/components/nav-bar/index.js
@@ -53,6 +53,16 @@ class NavBar extends Component {
     ipcRenderer.removeListener('nav.focus', this.focusUrlInput);
   }
 
+  // Check if there's a url update, and set state accordingly so
+  // correct url is displayed in navbar
+  componentDidUpdate(prevProps) {
+    if (this.props.url !== prevProps.url) {
+      this.setState({
+        url: this.props.url
+      })
+    }
+  }
+
   /**
    * Renders the settings button for changing opacity
    * @return {*}

--- a/src/components/web-page/index.js
+++ b/src/components/web-page/index.js
@@ -51,6 +51,13 @@ class WebPage extends React.Component {
         this.props.onUrl(newUrl);
       }
     });
+
+    // Capture link clicks on page and update state with new url
+    currentWebView.addEventListener('did-navigate', (event) => {
+      this.setState({
+        url: event.url
+      });
+    });
   }
 
   onReload = () => {

--- a/src/components/web-page/index.js
+++ b/src/components/web-page/index.js
@@ -58,6 +58,13 @@ class WebPage extends React.Component {
         url: event.url
       });
     });
+
+    // Also handle in-page navigation
+    currentWebView.addEventListener('did-navigate-in-page', (event) => {
+      this.setState({
+        url: event.url
+      });
+    });
   }
 
   onReload = () => {


### PR DESCRIPTION
**Related Issue**
Fixes #51

When the user clicks on links in the browser, the url in the navbar will now update accordingly. The link clicks are captured using the `did-navigate` DOM event.

Note: When entering a url that is without protocol (e.g. github.com) it will now first resolve to http://github.com and then finally to https://github.com/ but I'm not sure why this is. Also seems to now force a trailing slash. You can see this behavior in the capture below, along with the new url update behavior.

<img src="https://user-images.githubusercontent.com/17421347/48029407-f916b800-e102-11e8-93da-a17c45d47ddb.gif" width="400">
