### PR TITLE
Recover code about close window

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -87,6 +87,7 @@ function setMainMenu(mainWindow) {
             });
           }
         },
+        { role: 'close' },
         { type: 'separator' },
         { role: 'quit' },
       ]


### PR DESCRIPTION
**Related PR**
#50 

Disappear feature about close window in menu.

In #50, Added feature.
In [this](https://github.com/kamranahmedse/pennywise/commit/6176d2451452493ea319eb5689b0973a9ed4678b#diff-708e7cad0f39c5381737032ca5af1d6eR93), It is edited.
In [this](https://github.com/kamranahmedse/pennywise/commit/b75ff11a6179c2a7e9a212ad02de9151fef0a509#diff-708e7cad0f39c5381737032ca5af1d6eR91), It is deleted!

I think it is mistake. If not, Is there a reason why it was deleted? 
