### PR TITLE
Make 'empty-page' responsive

### DIFF
--- a/src/components/empty-page/style.scss
+++ b/src/components/empty-page/style.scss
@@ -1,7 +1,6 @@
 .empty-page {
   padding-top: 1px;
   max-width: 560px;
-  min-height: 100vh;
   text-align: center;
   min-height: 100vh;
   margin: 0 auto;
@@ -12,21 +11,26 @@
 
   h1 {
     font-weight: 700;
-    font-size: 10vh;
+    font-size: 55px;
     margin-bottom: 1vh;
+    @media (max-height: 300px) {
+      display: none;
+    }
   }
 
   p {
-    font-size: 3.5vh;
+    font-size: 18px;
     font-weight: 500;
-    margin-bottom: 2vh;
+    @media (max-height: 425px) {
+      display: none;
+    }
   }
 
   input {
-    font-size: 3.5vh;
+    font-size: 18px;
     font-weight: 500;
-    margin-top: 1vh;
-    padding: 3vh 4vh;
+    margin-top: 1.5vh;
+    padding: 15px 20px;
     box-shadow: none;
     border-radius: 80px;
     border: none;
@@ -38,7 +42,11 @@
 
   svg {
     width: 50vh;
-    margin-bottom: 1.5vh;
+    height: 50vh;
+    margin-bottom: 2vh;
+    @media (max-height: 125px) {
+      display: none;
+    }
   }
 }
 

--- a/src/components/empty-page/style.scss
+++ b/src/components/empty-page/style.scss
@@ -13,7 +13,7 @@
     font-weight: 700;
     font-size: 55px;
     margin-bottom: 1vh;
-    @media (max-height: 300px) {
+    @media (max-height: 140px) {
       display: none;
     }
   }
@@ -21,7 +21,7 @@
   p {
     font-size: 18px;
     font-weight: 500;
-    @media (max-height: 425px) {
+    @media (max-height: 190px) {
       display: none;
     }
   }
@@ -42,9 +42,14 @@
 
   svg {
     width: 50vh;
-    height: 50vh;
     margin-bottom: 2vh;
-    @media (max-height: 125px) {
+    @media (max-height: 400px) {
+      width: 40vh;
+    }
+    @media (max-height: 320px) {
+      width: 30vh;
+    }
+    @media (max-height: 250px) {
       display: none;
     }
   }

--- a/src/components/empty-page/style.scss
+++ b/src/components/empty-page/style.scss
@@ -1,6 +1,7 @@
 .empty-page {
   padding-top: 1px;
   max-width: 560px;
+  min-height: 100vh;
   text-align: center;
   min-height: 100vh;
   margin: 0 auto;
@@ -11,20 +12,21 @@
 
   h1 {
     font-weight: 700;
-    font-size: 55px;
-    margin-bottom: 10px;
+    font-size: 10vh;
+    margin-bottom: 1vh;
   }
 
   p {
-    font-size: 18px;
+    font-size: 3.5vh;
     font-weight: 500;
+    margin-bottom: 2vh;
   }
 
   input {
-    font-size: 18px;
+    font-size: 3.5vh;
     font-weight: 500;
-    margin-top: 15px;
-    padding: 15px 20px;
+    margin-top: 1vh;
+    padding: 3vh 4vh;
     box-shadow: none;
     border-radius: 80px;
     border: none;
@@ -35,9 +37,8 @@
   }
 
   svg {
-    width: 250px;
-    height: 250px;
-    margin-bottom: 20px;
+    width: 50vh;
+    margin-bottom: 1.5vh;
   }
 }
 


### PR DESCRIPTION
hello :wave: !

This adds `@media` queries to the elements on the `empty-page` to stop the scroll bars appearing when pennywise is set to a smaller size.

The logo has had it's size changed to `vh` so it can be kept as long as possible.

| Before                                                                          | After                                                                          |
|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
|  [![before](https://i.imgur.com/3Yn6CSTm.png)](https://i.imgur.com/3Yn6CST.png) |  [![after](https://i.imgur.com/HFmauZ2m.png)](https://i.imgur.com/HFmauZ2.png) |


### Before gif
![before](https://user-images.githubusercontent.com/13941027/48128551-bd086200-e27e-11e8-9832-289007d577bf.gif)


### After gif
![after](https://user-images.githubusercontent.com/13941027/48128558-c1347f80-e27e-11e8-8acd-363b501f6116.gif)


<details>
 <summary>Previous</summary>
<p>

This changes size values in `empty-page/style.scss` to use `vh` instead of `px` values. This means if Pennywise is small, the url bar is still visible, and scroll bars don't appear.

I tried to keep the initial open state sizes very similar, but there is some slight differences.

| Before                                                                          | After                                                                          |
|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
|  [![before](https://i.imgur.com/rpGtkmkm.png)](https://i.imgur.com/rpGtkmk.png) |  [![after](https://i.imgur.com/cfE1NuEm.png)](https://i.imgur.com/cfE1NuE.png) |


### Before gif
![before](https://user-images.githubusercontent.com/13941027/48067794-0bf3c000-e1c9-11e8-8c06-bcccdac1eff3.gif)

### After gif
![after](https://user-images.githubusercontent.com/13941027/48067801-0e561a00-e1c9-11e8-9740-a80945d6e0ea.gif)

</p>
</details>

