### PR TITLE
Typo Fix about release page link.

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -184,7 +184,7 @@ function setMainMenu(mainWindow) {
         {
           label: `About Version`,
           click() {
-            shell.openExternal(`https://github.com/kamranahmedse/pennywise/releases/tag/${appVersion}`);
+            shell.openExternal(`https://github.com/kamranahmedse/pennywise/releases/tag/v${appVersion}`);
           }
         },
       ]


### PR DESCRIPTION
**What does this PR do?**
Bug Fix about release page link.
Ref to #85.

I show [homebrew-cask PR about Pennywise](https://github.com/Homebrew/homebrew-cask/pull/54746/commits/737e0343ce3385576e5f76827c993d191a287bd4#diff-4924fc0fb359655e31ee73269f662b24R5).
 It show that future versions seem to include prefix v of version.
So I fix it.
