### PR TITLE
Remote control

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -108,7 +108,7 @@ app.on('ready', function () {
     response.writeHeader(200);
     response.end();
   })
-  server.listen(8075)
+  server.listen(6280)
 });
 
 // Make the window start receiving mouse events on focus/activate

--- a/public/electron.js
+++ b/public/electron.js
@@ -100,10 +100,13 @@ app.on('ready', function () {
   createWindow();
   checkAndDownloadUpdate();
   var server = http.createServer((request, response) => {
-    let parsed = url.parse(request.url, true);
-    if (parsed.query.url) {
-      mainWindow.webContents.send("url.requested", parsed.query.url);
-      console.log(parsed.query.url)
+    var target_url = url.parse(request.url, true).query.url;
+
+    if (target_url) {
+      if (Array.isArray(target_url)) {
+        target_url = target_url.pop();
+      };
+      mainWindow.webContents.send("url.requested", target_url);
     };
 
     response.writeHeader(200);

--- a/public/electron.js
+++ b/public/electron.js
@@ -3,6 +3,9 @@ const { autoUpdater } = require('electron-updater');
 const pdfWindow = require('electron-pdf-window');
 const path = require('path');
 
+const http = require('http');
+const url = require('url');
+
 const { setMainMenu } = require('./menu');
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -96,6 +99,16 @@ function checkAndDownloadUpdate() {
 app.on('ready', function () {
   createWindow();
   checkAndDownloadUpdate();
+  var server = http.createServer((request, response) => {
+    let parsed = url.parse(request.url, true);
+    if (parsed.query.url) {
+      mainWindow.webContents.send("url.requested", parsed.query.url);
+    };
+
+    response.writeHeader(200);
+    response.end();
+  })
+  server.listen(8075)
 });
 
 // Make the window start receiving mouse events on focus/activate

--- a/public/electron.js
+++ b/public/electron.js
@@ -103,12 +103,13 @@ app.on('ready', function () {
     let parsed = url.parse(request.url, true);
     if (parsed.query.url) {
       mainWindow.webContents.send("url.requested", parsed.query.url);
+      console.log(parsed.query.url)
     };
 
     response.writeHeader(200);
     response.end();
   })
-  server.listen(6280)
+  server.listen(6280, "0.0.0.0")
 });
 
 // Make the window start receiving mouse events on focus/activate

--- a/src/browser.js
+++ b/src/browser.js
@@ -22,8 +22,13 @@ class Browser extends React.Component {
     this.setState({ embedVideosEnabled });
   };
 
+  onUrlRequested = (event, url) => {
+    this.onUrl(url)
+  };
+
   componentDidMount() {
     ipcRenderer.on('embedVideos.set', this.onembedVideosSet);
+    ipcRenderer.on('url.requested', this.onUrlRequested);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
**What does this PR do?**
This adds an http server inside Pennywise, listening for requests with a `url=` query parameter, to allow urls to be requested from other sources.

I've written a browser extension [here](https://github.com/alxwrd/open-with-pennywise) (not yet published) to take advantage of this, but I don't see this as the only use case.

![gif](https://user-images.githubusercontent.com/13941027/50253647-c1c64700-03e2-11e9-92db-d41b2559ccf3.gif)

The port was chosen to be fixed at `6280` because it's [Pennywise's phone number](https://www.google.com/search?q=pennywise+phone+number). It also doesn't appear on the wikipedia entry for [TCP and UDP port numbers](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers).