### PR TITLE
Enable flash support

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -6,12 +6,25 @@ const argv = require('yargs').parse(process.argv.slice(1));
 
 const http = require('http');
 const url = require('url');
+const fs = require('fs');
+const os = require('os');
 
 const { setMainMenu } = require('./menu');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;
+
+// Add flash support. If $USER_HOME/.pennywise-flash exists as plugin directory or symlink uses that.
+const flashPath = path.join(os.homedir(), ".pennywise-flash");
+if (flashPath && fs.existsSync(flashPath)) {
+  try{
+    app.commandLine.appendSwitch('ppapi-flash-path', fs.realpathSync(flashPath));
+    console.log("Attempting to load flash at " + flashPath)
+  }catch (e){
+    console.log("Error finding flash at " + flashPath + ": " + e.message);
+  }
+}
 
 function createWindow() {
   mainWindow = new BrowserWindow({

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,15 @@ If you are on MacOS, you can use [Homebrew](https://brew.sh/) to install it
 ```
 brew cask install pennywise
 ```
+To enable flash support, copy Chrome's Pepperflash plugin into your $USER-DIR/.pennywise-flash. Or better yet create a symlink to the plugin installed with your browser. See chrome://flash in your browser for installation path.
+
+e.g. on MacOS
+
+```
+ln -s "/Users/colint/Library/Application Support/Google/Chrome/PepperFlash/32.0.0.156/PepperFlashPlayer.plugin" .pennywise-flash
+
+```
+Using flash is at your own risk and should only be done with sites you trust!
 
 ## Usecases
 


### PR DESCRIPTION
To enable flash we need to set the commandline switch 'ppapi-flash-path' for the electron app.
We look for the file .pennywise-flash in the users home dir expecting to be a copy of a the PepperflashPlugin or a symlink to it. A users flash install can be found in chrome://flash.

**What does this PR do?**
Enable flash.

**What platforms did you test it on?**
Only mac available unfortunately but it is trivial change and should be fine on all platforms.

