### PR TITLE
Set background-color of webpage to whitesmoke

### DIFF
--- a/src/components/web-page/style.scss
+++ b/src/components/web-page/style.scss
@@ -4,6 +4,7 @@
   height: 100vh;
   overflow-x: hidden;
   overflow-y: hidden;
+  background-color: whitesmoke;
 
   webview {
     display: inline-flex !important;


### PR DESCRIPTION
**What does this PR do?**
This PR sets the background-color of webpage to whitesmoke on default. I don't think this should conflict anytime, because the background-color doesn't affect the webview.
Media Files still have their black background.
**What platforms did you test it on?**
Ubuntu 19.04
![image](https://user-images.githubusercontent.com/38109072/76711640-12c20980-6712-11ea-8364-cbe09426b056.png)
![image](https://user-images.githubusercontent.com/38109072/76711663-28373380-6712-11ea-8efa-70373af0d78d.png)

