### PR TITLE
Rewrite the t parameter when embedding YouTube videos

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -30,6 +30,16 @@ const prepareYoutubeUrl = (url) => {
 
   queryParams.autoplay = 1;
 
+  // Rewrite the t parameter to start
+  // YouTube uses start and end when embedding videos
+  if (queryParams.t) {
+    const timestampMatch = /^(\d+)s$/.exec(queryParams.t)
+    if (timestampMatch) {
+      queryParams.start = timestampMatch[1]
+      delete queryParams.t
+    }
+  }
+
   return `https://www.youtube.com/embed/${videoHash}?${queryString.stringify(queryParams)}`;
 };
 


### PR DESCRIPTION
**What does this PR do?**
YouTube uses the `t` parameter to start the video at an offset. For example, this happens when copying a YouTube URL of a video you already watched partially. However, for embedded videos YouTube uses the `start` and `end` parameters to 'cut' the video ([source](https://support.google.com/youtube/answer/171780?hl=en)). Currently this offset will be lost when rewriting the URL to an embedded video.

This PR will rewrite the `t` parameter to `start`, making sure the embedded video continues at the point specified by the original URL. The `s` suffix needs to be removed for this.

**What platforms did you test it on?**
`Linux 5.4.40-1-MANJARO x86_64`

