### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Download and install the relevant distribution from the [releases page](http://g
 If you are on MacOS, you can use [Homebrew](https://brew.sh/) to install it
 
 ```
-brew cask install pennywise
+brew install --cask pennywise
 ```
 
 ### Enable Flash Support


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103261746-e8fa7a80-49e5-11eb-9685-da37c4e6de3e.png)

